### PR TITLE
Added :asset-path to build edn.

### DIFF
--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,2 +1,3 @@
 {:main hello-world.core
+ :asset-path "target/node/dev"
  :target :nodejs}


### PR DESCRIPTION
This allows a successful compilation under Windows. Now we must only figure out why the pure Windows jack-in on your system does not work. *gg* 